### PR TITLE
Add DEM sampling helper

### DIFF
--- a/src/stim/simulators/dem_sampler.h
+++ b/src/stim/simulators/dem_sampler.h
@@ -75,6 +75,15 @@ struct DemSampler {
         SampleFormat replay_err_in_format);
 };
 
+/// Convenience method for sampling detection events from a detector error model.
+///
+/// Uses DemSampler internally and stores all results in memory at once. The
+/// returned tables have the detector (or observable) index as their major axis
+/// and the shot index as their minor axis.
+template <size_t W>
+std::pair<simd_bit_table<W>, simd_bit_table<W>> sample_batch_detection_events(
+    const DetectorErrorModel &model, size_t num_shots, std::mt19937_64 &rng);
+
 }  // namespace stim
 
 #include "stim/simulators/dem_sampler.inl"

--- a/src/stim/simulators/dem_sampler.inl
+++ b/src/stim/simulators/dem_sampler.inl
@@ -127,4 +127,17 @@ void DemSampler<W>::sample_write(
     }
 }
 
+template <size_t W>
+std::pair<simd_bit_table<W>, simd_bit_table<W>> sample_batch_detection_events(
+    const DetectorErrorModel &model, size_t num_shots, std::mt19937_64 &rng) {
+    DemSampler<W> sampler(model, std::move(rng), num_shots);
+    sampler.resample(false);
+    simd_bit_table<W> dets((size_t)sampler.num_detectors, num_shots);
+    simd_bit_table<W> obs((size_t)sampler.num_observables, num_shots);
+    sampler.det_buffer.copy_into_different_size_table(dets);
+    sampler.obs_buffer.copy_into_different_size_table(obs);
+    rng = std::move(sampler.rng);
+    return {std::move(dets), std::move(obs)};
+}
+
 }  // namespace stim

--- a/src/stim/simulators/dem_sampler.test.cc
+++ b/src/stim/simulators/dem_sampler.test.cc
@@ -98,3 +98,16 @@ TEST_EACH_WORD_SIZE_W(DemSampler, resample_combinations, {
         ASSERT_FALSE(total.not_zero());
     }
 })
+
+TEST_EACH_WORD_SIZE_W(DemSampler, sample_batch_detection_events, {
+    auto rng = INDEPENDENT_TEST_RNG();
+    DetectorErrorModel dem(R"DEM(
+        error(1) D0 L0
+        error(0) D1
+    )DEM");
+    auto result = sample_batch_detection_events<W>(dem, 5, rng);
+    ASSERT_EQ(result.first[0].popcnt(), 5);
+    ASSERT_EQ(result.first[1].popcnt(), 0);
+    ASSERT_EQ(result.second[0].popcnt(), 5);
+})
+


### PR DESCRIPTION
## Summary
- add `sample_batch_detection_events` overload for `DetectorErrorModel`
- implement function in `dem_sampler` utilities
- test sampling from a DEM

## Testing
- `pytest -q` *(fails: missing pybind11 during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685d8bfcd9d88320aac50d732bb06556